### PR TITLE
Mergeback v-1.0

### DIFF
--- a/libndt7/build.gradle
+++ b/libndt7/build.gradle
@@ -14,14 +14,14 @@ publishing {
     publications {
         release(MavenPublication) {
             groupId 'net.measurementlab.ndt7.android'
-            artifactId 'libndt7'
+            artifactId 'mirror-libndt7'
             version mavenVersion
             artifact("$buildDir/outputs/aar/libndt7-release.aar")
         }
 
         debug(MavenPublication) {
             groupId 'net.measurementlab.ndt7.android'
-            artifactId 'libndt7-debug'
+            artifactId 'mirror-libndt7-debug'
             version mavenVersion
             artifact("$buildDir/outputs/aar/libndt7-debug.aar")
         }


### PR DESCRIPTION
Updates `artifactId` to use an explicit `mirror` prefix to denote the forked publication